### PR TITLE
Fix race on record state

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -299,7 +299,7 @@ func (c *Cache) Set(key, value interface{}, ttl time.Duration) {
 		c.runLoopOnce()
 	}
 	doEvict := func(r *record) {
-		if c.mode == ModeNonBlocking && r.IsEvicting() {
+		if c.mode == ModeNonBlocking && r.Evicting() {
 			r.evictionWg.Wait()
 			return
 		}
@@ -385,7 +385,7 @@ func (c *Cache) Fetch(key interface{}, ttl time.Duration, f FetchCallback) (valu
 			c.pool.Put(new)
 			return v, r, nil
 		}
-		if c.mode == ModeNonBlocking && r.IsEvicting() {
+		if c.mode == ModeNonBlocking && r.Evicting() {
 			r.evictionWg.Wait()
 		}
 	}
@@ -460,10 +460,10 @@ func (c *Cache) finalize(key interface{}, r *record) (value interface{}) {
 		c.pool.Put(r)
 		return value
 	}
-	c.wg.Add(1)
 	if c.mode == ModeBlocking {
 		r.evictionWg.Add(1)
 	}
+	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
 		r.readerWg.Wait()

--- a/cache.go
+++ b/cache.go
@@ -299,6 +299,10 @@ func (c *Cache) Set(key, value interface{}, ttl time.Duration) {
 		c.runLoopOnce()
 	}
 	doEvict := func(r *record) {
+		if r.IsEvicting() {
+			r.evictionWg.Wait()
+			return
+		}
 		defer c.Evict(key)
 		if !r.Active() {
 			// Wait for any pending Fetch callback.
@@ -316,6 +320,7 @@ func (c *Cache) Set(key, value interface{}, ttl time.Duration) {
 			defer c.mu.Unlock()
 			front = c.list.PushBack(key, new.ring)
 			new.init(value, ttl)
+			new.setState(stateActive)
 			return
 		}
 		doEvict(old.(*record))
@@ -362,8 +367,9 @@ func (c *Cache) Fetch(key interface{}, ttl time.Duration, f FetchCallback) (valu
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		front = c.list.PushBack(key, new.ring)
-		new.wg.Add(1)
+		new.readerWg.Add(1)
 		new.init(value, ttl)
+		new.setState(stateActive)
 		return nil, false
 	}
 	for {
@@ -378,6 +384,9 @@ func (c *Cache) Fetch(key interface{}, ttl time.Duration, f FetchCallback) (valu
 		if v, ok := r.LoadAndHit(); ok {
 			c.pool.Put(new)
 			return v, r, nil
+		}
+		if r.IsEvicting() {
+			r.evictionWg.Wait()
 		}
 	}
 }
@@ -428,6 +437,8 @@ func (c *Cache) load(key interface{}) *record {
 	}
 	r := old.(*record)
 	if !r.Active() {
+		// fmt.Println(r.state)
+		// fmt.Println("not active")
 		return nil
 	}
 	return r
@@ -436,56 +447,35 @@ func (c *Cache) load(key interface{}) *record {
 // It is safe to lock r.mu while holding c.mu,
 // the record is already active.
 func (c *Cache) finalize(key interface{}, r *record) (value interface{}) {
-	switch c.mode {
-	case ModeNonBlocking:
-		return c.finalizeNonBlocking(key, r)
-	default:
-		return c.finalizeBlocking(key, r)
+	if c.mode == ModeNonBlocking {
+		c.records.Delete(key)
 	}
-}
-
-func (c *Cache) finalizeNonBlocking(key interface{}, r *record) (value interface{}) {
-	c.records.Delete(key)
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.setState(stateEvicting)
 	value = r.loadAndReset()
 	if k := c.list.Remove(r.ring); k != nil && k != key {
 		panic("evcache: invalid ring")
 	}
 	if c.afterEvict == nil {
+		r.setState(stateInactive)
 		c.pool.Put(r)
 		return value
 	}
 	c.wg.Add(1)
+	r.evictionWg.Add(1)
 	go func() {
 		defer c.wg.Done()
-		r.wg.Wait()
-		c.pool.Put(r)
-		c.afterEvict(key, value)
-	}()
-	return value
-}
-
-func (c *Cache) finalizeBlocking(key interface{}, r *record) (value interface{}) {
-	r.mu.Lock()
-	if c.afterEvict == nil {
-		defer r.mu.Unlock()
-	}
-	value = r.loadAndReset()
-	if k := c.list.Remove(r.ring); k != nil && k != key {
-		panic("evcache: invalid ring")
-	}
-	if c.afterEvict == nil {
-		c.pool.Put(r)
-		return value
-	}
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
-		r.wg.Wait()
-		defer c.pool.Put(r)
-		defer r.mu.Unlock()
-		defer c.records.Delete(key)
+		defer r.evictionWg.Done()
+		r.readerWg.Wait()
+		if c.mode == ModeNonBlocking {
+			r.setState(stateInactive)
+			c.pool.Put(r)
+		} else {
+			defer c.pool.Put(r)
+			defer r.setState(stateInactive)
+			defer c.records.Delete(key)
+		}
 		c.afterEvict(key, value)
 	}()
 	return value

--- a/cache.go
+++ b/cache.go
@@ -437,8 +437,6 @@ func (c *Cache) load(key interface{}) *record {
 	}
 	r := old.(*record)
 	if !r.Active() {
-		// fmt.Println(r.state)
-		// fmt.Println("not active")
 		return nil
 	}
 	return r

--- a/record.go
+++ b/record.go
@@ -10,12 +10,14 @@ import (
 const (
 	stateInactive uint32 = iota
 	stateActive
+	stateEvicting
 )
 
 type record struct {
-	mu   sync.RWMutex
-	wg   sync.WaitGroup
-	ring *ring.Ring
+	mu         sync.RWMutex
+	readerWg   sync.WaitGroup
+	evictionWg sync.WaitGroup
+	ring       *ring.Ring
 
 	value   interface{}
 	expires int64
@@ -28,12 +30,16 @@ func newRecord() *record {
 }
 
 func (r *record) Close() error {
-	r.wg.Done()
+	r.readerWg.Done()
 	return nil
 }
 
 func (r *record) Active() bool {
 	return atomic.LoadUint32(&r.state) == stateActive
+}
+
+func (r *record) IsEvicting() bool {
+	return atomic.LoadUint32(&r.state) == stateEvicting
 }
 
 func (r *record) Expired(now int64) bool {
@@ -57,14 +63,18 @@ func (r *record) LoadAndHit() (interface{}, bool) {
 		return nil, false
 	}
 	atomic.AddUint32(&r.hits, 1)
-	r.wg.Add(1)
+	r.readerWg.Add(1)
 	return r.value, true
 }
 
-func (r *record) init(value interface{}, ttl time.Duration) {
-	if !atomic.CompareAndSwapUint32(&r.state, stateInactive, stateActive) {
+func (r *record) setState(newState uint32) {
+	prevState := (newState + 3 - 1) % 3
+	if !atomic.CompareAndSwapUint32(&r.state, prevState, newState) {
 		panic("evcache: invalid record state")
 	}
+}
+
+func (r *record) init(value interface{}, ttl time.Duration) {
 	r.value = value
 	if ttl > 0 {
 		atomic.StoreInt64(&r.expires, time.Now().Add(ttl).UnixNano())
@@ -72,9 +82,6 @@ func (r *record) init(value interface{}, ttl time.Duration) {
 }
 
 func (r *record) loadAndReset() interface{} {
-	if !atomic.CompareAndSwapUint32(&r.state, stateActive, stateInactive) {
-		panic("evcache: invalid record state")
-	}
 	value := r.value
 	r.value = nil
 	atomic.StoreInt64(&r.expires, 0)

--- a/record.go
+++ b/record.go
@@ -38,7 +38,7 @@ func (r *record) Active() bool {
 	return atomic.LoadUint32(&r.state) == stateActive
 }
 
-func (r *record) IsEvicting() bool {
+func (r *record) Evicting() bool {
 	return atomic.LoadUint32(&r.state) == stateEvicting
 }
 


### PR DESCRIPTION
There was a race condition in the new blocking eviction mode where holding the record mutex would have cause the readers check-lock-check to fail and still block. Instead, the mutex is only locked for a short time like before but an added waitgroup is now used to make `Fetch` and `Set` wait for eviction callback to finish (which in turn waits for users to finish).