### PR TITLE
Drop sync.Pool from eviction

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -460,7 +460,6 @@ func (c *Cache) finalize(key interface{}, r *record) (value interface{}) {
 	}
 	if c.afterEvict == nil {
 		r.setState(stateInactive)
-		c.pool.Put(r)
 		return value
 	}
 	if c.mode == ModeBlocking {
@@ -472,9 +471,7 @@ func (c *Cache) finalize(key interface{}, r *record) (value interface{}) {
 		r.readerWg.Wait()
 		if c.mode == ModeNonBlocking {
 			r.setState(stateInactive)
-			c.pool.Put(r)
 		} else {
-			defer c.pool.Put(r)
 			defer r.evictionWg.Done()
 			defer r.setState(stateInactive)
 			defer c.records.Delete(key)


### PR DESCRIPTION
This might caused a race condition where we don't know how many contenders there are to the record mutex. If it is reused, readers may read another key's value, so the record must be dropped. It doesn't affect `Fetch` - the record is not stored into the map.