### PR TITLE
Lock record during delete

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -409,6 +409,13 @@ func (c *Cache) deleteLocked(key interface{}, target *interface{}) (value interf
 	if r.State() != active {
 		return nil, false
 	}
+	// Safe to lock r.mu on an active record
+	// while holding c.mu.
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.State() != active {
+		return nil, false
+	}
 	value = r.value
 	if target != nil && !reflect.DeepEqual(value, *target) {
 		return nil, false

--- a/cache.go
+++ b/cache.go
@@ -413,9 +413,6 @@ func (c *Cache) deleteLocked(key interface{}, target *interface{}) (value interf
 	// while holding c.mu.
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.State() != active {
-		return nil, false
-	}
 	value = r.value
 	if target != nil && !reflect.DeepEqual(value, *target) {
 		return nil, false


### PR DESCRIPTION
The record state change from active -> evicting needs to be guarded by the record's lock in addition to cache lock since readers use the record's read lock.