### PR TITLE
Implement LFU and LRU eviction policies

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.21
 
       - name: Run test
-        run: go test -race
+        run: go test -race ./...
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       - name: Run test
         run: go test -race
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,66 @@
+package evcache_test
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mgnsk/evcache/v3"
+)
+
+func BenchmarkFetchAndEvictParallel(b *testing.B) {
+	b.StopTimer()
+
+	c := evcache.New[uint64, int](0)
+	index := uint64(0)
+	errFetch := errors.New("error fetching")
+
+	b.ReportAllocs()
+	b.StartTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if idx := atomic.AddUint64(&index, 1); idx%2 == 0 {
+				_, _ = c.Fetch(0, 0, func() (int, error) {
+					if idx%4 == 0 {
+						return 0, errFetch
+					}
+					return 0, nil
+				})
+			} else {
+				c.Evict(0)
+			}
+		}
+	})
+}
+
+func BenchmarkFetchExists(b *testing.B) {
+	b.StopTimer()
+
+	c := evcache.New[uint64, int](0)
+	c.LoadOrStore(0, 0, 0)
+
+	b.ReportAllocs()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = c.Fetch(0, 0, func() (int, error) {
+			panic("unexpected fetch callback")
+		})
+	}
+}
+
+func BenchmarkFetchNotExists(b *testing.B) {
+	b.StopTimer()
+
+	c := evcache.New[int, int](0)
+
+	b.ReportAllocs()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = c.Fetch(i, 0, func() (int, error) {
+			return 0, nil
+		})
+	}
+}

--- a/benchmark_all_commits.sh
+++ b/benchmark_all_commits.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source=$(pwd)
+tmp=$(mktemp -d)
+cp -r ./ "$tmp/"
+cd "$tmp"
+
+# find commits since the beginning of time
+for commit in $(git log --reverse --pretty=format:"%h"); do
+	echo ""
+	echo "Benchmarking commit $commit"
+	echo ""
+
+	git checkout "$commit"
+	message=$(git log --format=%B -n 1 "$commit")
+
+	output=$(go test -run=^a -bench=. ./... || true)
+	echo "$output" | gobenchdata -v "$commit" -t "$message" -a --json "$source/benchmarks.json" || true
+done
+
+rm -rf "$tmp"

--- a/cache.go
+++ b/cache.go
@@ -30,6 +30,29 @@ func New[K comparable, V any](capacity int) *Cache[K, V] {
 	return c
 }
 
+// Available cache eviction policies.
+const (
+	Default = "default"
+	LRU     = "lru"
+	LFU     = "lfu"
+)
+
+// WithPolicy configures the cache with specified eviction policy.
+func (c *Cache[K, V]) WithPolicy(policy string) *Cache[K, V] {
+	if policy != "" {
+		switch policy {
+		case Default:
+		case LRU:
+			c.backend.Policy = backend.LRU
+		case LFU:
+			c.backend.Policy = backend.LFU
+		default:
+			panic("evcache: invalid eviction policy '" + policy + "'")
+		}
+	}
+	return c
+}
+
 // Exists returns whether a value in the cache exists for key.
 func (c *Cache[K, V]) Exists(key K) bool {
 	_, ok := c.backend.Load(key)
@@ -39,7 +62,7 @@ func (c *Cache[K, V]) Exists(key K) bool {
 // Get returns the value stored in the cache for key.
 func (c *Cache[K, V]) Get(key K) (value V, exists bool) {
 	if elem, ok := c.backend.Load(key); ok {
-		return elem.Value.Value(), true
+		return elem.Value, true
 	}
 
 	var zero V
@@ -51,8 +74,8 @@ func (c *Cache[K, V]) Get(key K) (value V, exists bool) {
 //
 // Range is allowed to modify the cache.
 func (c *Cache[K, V]) Range(f func(key K, value V) bool) {
-	c.backend.Range(func(key K, elem backend.Element[V]) bool {
-		return f(key, elem.Value.Value())
+	c.backend.Range(func(key K, elem *backend.Element[V]) bool {
+		return f(key, elem.Value)
 	})
 }
 
@@ -64,7 +87,7 @@ func (c *Cache[K, V]) Len() int {
 // Evict a key and return its value.
 func (c *Cache[K, V]) Evict(key K) (value V, ok bool) {
 	if elem, ok := c.backend.Evict(key); ok {
-		return elem.Value.Value(), true
+		return elem.Value, true
 	}
 
 	var zero V
@@ -111,10 +134,10 @@ loadOrStore:
 	if elem, initialized, loaded := c.backend.LoadOrStore(key, newElem); loaded {
 		if initialized {
 			c.backend.Release(newElem)
-			return elem.Value.Value(), nil
+			return elem.Value, nil
 		}
 
-		elem.Value.Wait()
+		elem.Wait()
 
 		goto loadOrStore
 	}
@@ -137,7 +160,7 @@ loadOrStore:
 		return zero, err
 	}
 
-	c.backend.Initialize(key, value, ttl)
+	c.backend.Initialize(newElem, value, ttl)
 
 	return value, nil
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -3,8 +3,6 @@ package evcache_test
 import (
 	"errors"
 	"fmt"
-	"runtime"
-	"sort"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -17,9 +15,9 @@ func TestLoadOrStoreNotExists(t *testing.T) {
 	c := evcache.New[string, int](0)
 
 	_, loaded := c.LoadOrStore("key", 0, 1)
-	AssertEqual(t, loaded, false)
-	AssertEqual(t, c.Exists("key"), true)
-	AssertEqual(t, c.Len(), 1)
+	Equal(t, loaded, false)
+	Equal(t, c.Exists("key"), true)
+	Equal(t, c.Len(), 1)
 }
 
 func TestLoadOrStoreExists(t *testing.T) {
@@ -28,8 +26,8 @@ func TestLoadOrStoreExists(t *testing.T) {
 	c.LoadOrStore("key", 0, 1)
 
 	v, loaded := c.LoadOrStore("key", 0, 2)
-	AssertEqual(t, loaded, true)
-	AssertEqual(t, v, 1)
+	Equal(t, loaded, true)
+	Equal(t, v, 1)
 }
 
 func TestFetchCallbackBlocks(t *testing.T) {
@@ -50,23 +48,23 @@ func TestFetchCallbackBlocks(t *testing.T) {
 	<-fetchStarted
 
 	t.Run("non-blocking Exists", func(t *testing.T) {
-		AssertEqual(t, c.Exists("key"), false)
+		Equal(t, c.Exists("key"), false)
 	})
 
 	t.Run("non-blocking Evict", func(t *testing.T) {
 		_, ok := c.Evict("key")
-		AssertEqual(t, ok, false)
+		Equal(t, ok, false)
 	})
 
 	t.Run("non-blocking Get", func(t *testing.T) {
 		_, ok := c.Get("key")
-		AssertEqual(t, ok, false)
+		Equal(t, ok, false)
 	})
 
 	t.Run("autoexpiry for other keys works", func(t *testing.T) {
 		c.LoadOrStore("key1", time.Millisecond, "value1")
 
-		AssertEventuallyTrue(t, func() bool {
+		EventuallyTrue(t, func() bool {
 			return !c.Exists("key1")
 		})
 	})
@@ -81,15 +79,15 @@ func TestFetchCallbackBlocks(t *testing.T) {
 			}
 
 			v, ok := c.Evict(key)
-			AssertEqual(t, ok, true)
-			AssertEqual(t, v, value)
-			AssertEqual(t, c.Len(), 0)
+			Equal(t, ok, true)
+			Equal(t, v, value)
+			Equal(t, c.Len(), 0)
 
 			n++
 			return true
 		})
 
-		AssertEqual(t, n, 1)
+		Equal(t, n, 1)
 	})
 }
 
@@ -111,8 +109,8 @@ func TestFetchCallbackPanic(t *testing.T) {
 		return "new value", nil
 	})
 
-	AssertSuccess(t, err)
-	AssertEqual(t, v, "new value")
+	Must(t, err)
+	Equal(t, v, "new value")
 }
 
 func TestConcurrentFetch(t *testing.T) {
@@ -136,8 +134,8 @@ func TestConcurrentFetch(t *testing.T) {
 			return "value", nil
 		})
 
-		AssertSuccess(t, err)
-		AssertEqual(t, v, "value")
+		Must(t, err)
+		Equal(t, v, "value")
 	})
 
 	t.Run("returns value", func(t *testing.T) {
@@ -160,8 +158,8 @@ func TestConcurrentFetch(t *testing.T) {
 			return "value1", nil
 		})
 
-		AssertSuccess(t, err)
-		AssertEqual(t, v, "value")
+		Must(t, err)
+		Equal(t, v, "value")
 	})
 }
 
@@ -172,9 +170,9 @@ func TestEvict(t *testing.T) {
 
 	v, ok := c.Evict("key")
 
-	AssertEqual(t, ok, true)
-	AssertEqual(t, v, "value")
-	AssertEqual(t, c.Exists("key"), false)
+	Equal(t, ok, true)
+	Equal(t, v, "value")
+	Equal(t, c.Exists("key"), false)
 }
 
 func TestOverflow(t *testing.T) {
@@ -185,7 +183,7 @@ func TestOverflow(t *testing.T) {
 		c.LoadOrStore(i, 0, 0)
 	}
 
-	AssertEventuallyTrue(t, func() bool {
+	EventuallyTrue(t, func() bool {
 		return c.Len() == capacity
 	})
 }
@@ -200,7 +198,7 @@ func TestExpire(t *testing.T) {
 		_, _ = c.LoadOrStore(i, d, 0)
 	}
 
-	AssertEventuallyTrue(t, func() bool {
+	EventuallyTrue(t, func() bool {
 		return c.Len() == 0
 	})
 }
@@ -210,64 +208,26 @@ func TestExpireEdgeCase(t *testing.T) {
 
 	v1 := new(string)
 
-	c.LoadOrStore(0, 10*time.Millisecond, v1)
+	_, loaded := c.LoadOrStore(0, 10*time.Millisecond, v1)
+	Equal(t, loaded, false)
+	Equal(t, c.Len(), 1)
 
 	// Wait until v1 expires.
-	AssertEventuallyTrue(t, func() bool {
+	EventuallyTrue(t, func() bool {
 		return c.Len() == 0
 	})
 
 	// Assert that after v1 expires, v2 with a longer TTL than v1, can expire,
-	// specifically that runGC() resets earliestExpireAt to zero,
+	// specifically that backend's GC loop resets earliestExpireAt to zero,
 	// so that LoadOrStore schedules the GC loop.
 	v2 := new(string)
-	c.LoadOrStore(1, time.Second, v2)
+	_, loaded = c.LoadOrStore(1, 100*time.Millisecond, v2)
+	Equal(t, loaded, false)
+	Equal(t, c.Len(), 1)
 
-	AssertEventuallyTrue(t, func() bool {
+	EventuallyTrue(t, func() bool {
 		return c.Len() == 0
-	}, 2*time.Second)
-}
-
-func TestOverflowEvictionOrdering(t *testing.T) {
-	capacity := 10
-	c := evcache.New[int, *string](capacity)
-	evictedKeys := make(chan int)
-
-	// Fill the cache.
-	for i := 1; i <= capacity; i++ {
-		value := new(string)
-		i := i
-		runtime.SetFinalizer(value, func(any) {
-			evictedKeys <- i
-		})
-
-		_, loaded := c.LoadOrStore(i, 0, value)
-		AssertEqual(t, loaded, false)
-		AssertEqual(t, c.Len(), i)
-	}
-
-	// Overflow the cache and catch evicted keys.
-	var keys []int
-	for i := capacity + 1; i <= 2*capacity; i++ {
-		_, loaded := c.LoadOrStore(i, 0, nil)
-		AssertEqual(t, loaded, false)
-
-		// Run the GC until the value is garbage collected
-		// and the value finalizer runs.
-		AssertEventuallyTrue(t, func() bool {
-			runtime.GC()
-			select {
-			case key := <-evictedKeys:
-				keys = append(keys, key)
-				return true
-			default:
-				return false
-			}
-		})
-	}
-
-	AssertEqual(t, len(keys), capacity)
-	AssertEqual(t, sort.IntsAreSorted(keys), true)
+	})
 }
 
 func BenchmarkFetchAndEvictParallel(b *testing.B) {

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,9 +1,7 @@
 package evcache_test
 
 import (
-	"errors"
 	"fmt"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -228,51 +226,4 @@ func TestExpireEdgeCase(t *testing.T) {
 	EventuallyTrue(t, func() bool {
 		return c.Len() == 0
 	})
-}
-
-func BenchmarkFetchAndEvictParallel(b *testing.B) {
-	c := evcache.New[uint64, int](0)
-	index := uint64(0)
-	errFetch := errors.New("error fetching")
-	b.ReportAllocs()
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			if idx := atomic.AddUint64(&index, 1); idx%2 == 0 {
-				_, _ = c.Fetch(0, 0, func() (int, error) {
-					if idx%4 == 0 {
-						return 0, errFetch
-					}
-					return 0, nil
-				})
-			} else {
-				c.Evict(0)
-			}
-		}
-	})
-}
-
-func BenchmarkFetchExists(b *testing.B) {
-	c := evcache.New[uint64, int](0)
-	c.LoadOrStore(0, 0, 0)
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _ = c.Fetch(0, 0, func() (int, error) {
-			panic("unexpected fetch callback")
-		})
-	}
-}
-
-func BenchmarkFetchNotExists(b *testing.B) {
-	c := evcache.New[int, int](0)
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _ = c.Fetch(i, 0, func() (int, error) {
-			return 0, nil
-		})
-	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/mgnsk/evcache/v3
 
-go 1.19
-
-require github.com/mgnsk/ringlist v0.0.0-20231025190742-1f621b925911
+go 1.21

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mgnsk/evcache/v3
 
 go 1.21
+
+require github.com/mgnsk/ringlist v0.0.0-20231025190742-1f621b925911

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/mgnsk/ringlist v0.0.0-20231025190742-1f621b925911 h1:/RUn/noOFPYcnnlsXmdmHSvKBp5gwQ5OnlNX9bRgeZE=
-github.com/mgnsk/ringlist v0.0.0-20231025190742-1f621b925911/go.mod h1:fyW9CbxFtYtWazjV96eJt4r+B2ABDRu3/rXQOxxTjLE=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/mgnsk/ringlist v0.0.0-20231025190742-1f621b925911 h1:/RUn/noOFPYcnnlsXmdmHSvKBp5gwQ5OnlNX9bRgeZE=
+github.com/mgnsk/ringlist v0.0.0-20231025190742-1f621b925911/go.mod h1:fyW9CbxFtYtWazjV96eJt4r+B2ABDRu3/rXQOxxTjLE=

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -4,31 +4,28 @@ Package backend implements cache backend.
 package backend
 
 import (
-	"cmp"
-	"slices"
+	"maps"
 	"sync"
-	"sync/atomic"
 	"time"
+
+	"github.com/mgnsk/ringlist"
 )
 
 // Backend implements cache backend.
-// The map stores uninitialized or initialized elements, the list stores initialized or removed elements.
 type Backend[K comparable, V any] struct {
 	Policy           Policy
 	timer            *time.Timer
 	done             chan struct{}
-	xmap             map[K]*Element[V]
-	list             []*Element[V]
-	pool             sync.Pool
-	epoch            atomic.Uint64
+	xmap             map[K]*ringlist.Element[Record[V]] // map of uninitialized and initialized elements
+	list             ringlist.List[Record[V]]           // list of initialized elements
+	pool             sync.Pool                          // pool of elements
 	earliestExpireAt int64
 	cap              int
 	lastLen          int
-	len              int
 	numDeleted       uint64
 	needRealloc      bool
 	once             sync.Once
-	mu               sync.RWMutex
+	mu               sync.Mutex
 }
 
 // NewBackend creates a new cache backend.
@@ -39,8 +36,7 @@ func NewBackend[K comparable, V any](capacity int) *Backend[K, V] {
 	return &Backend[K, V]{
 		timer: t,
 		done:  make(chan struct{}),
-		xmap:  make(map[K]*Element[V], capacity),
-		list:  make([]*Element[V], 0, capacity),
+		xmap:  make(map[K]*ringlist.Element[Record[V]], capacity),
 		cap:   capacity,
 	}
 }
@@ -53,83 +49,84 @@ func (b *Backend[K, V]) Close() error {
 
 // Len returns the number of initialized elements.
 func (b *Backend[K, V]) Len() int {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
-	return b.len
+	return b.list.Len()
 }
 
 // Reserve a new uninitialized element.
-func (b *Backend[K, V]) Reserve() *Element[V] {
-	elem, ok := b.pool.Get().(*Element[V])
+func (b *Backend[K, V]) Reserve() *ringlist.Element[Record[V]] {
+	elem, ok := b.pool.Get().(*ringlist.Element[Record[V]])
 	if !ok {
-		elem = &Element[V]{}
+		elem = ringlist.NewElement(Record[V]{})
 	}
 
-	elem.wg.Add(1)
+	elem.Value.wg.Add(1)
 
 	return elem
 }
 
 // Release a reserved uninitialized element.
-func (b *Backend[K, V]) Release(elem *Element[V]) {
-	elem.wg.Done()
+func (b *Backend[K, V]) Release(elem *ringlist.Element[Record[V]]) {
+	defer elem.Value.wg.Done()
+
 	b.pool.Put(elem)
 }
 
 // Discard a reserved uninitialized element.
-func (*Backend[K, V]) Discard(elem *Element[V]) {
-	elem.wg.Done()
+func (b *Backend[K, V]) Discard(key K, elem *ringlist.Element[Record[V]]) {
+	defer elem.Value.wg.Done()
+
+	b.mu.Lock()
+	delete(b.xmap, key)
+	b.mu.Unlock()
 }
 
 // Initialize a previously stored uninitialized element.
-func (b *Backend[K, V]) Initialize(elem *Element[V], value V, ttl time.Duration) {
+func (b *Backend[K, V]) Initialize(elem *ringlist.Element[Record[V]], value V, ttl time.Duration) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if elem.initialized {
-		panic("Initialize: expected an uninitialized element")
-	}
+	defer elem.Value.wg.Done()
 
-	defer elem.wg.Done()
-
-	elem.Value = value
+	elem.Value.Value = value
 	if ttl > 0 {
-		elem.deadline = time.Now().Add(ttl).UnixNano()
+		elem.Value.deadline = time.Now().Add(ttl).UnixNano()
 	}
 
-	elem.initialized = true
-	b.list = append(b.list, elem)
-	b.len++
+	elem.Value.initialized = true
+	b.list.PushBack(elem)
 
 	if n := b.overflow(); n > 0 {
 		b.startGCOnce()
 		b.timer.Reset(0)
-	} else if elem.deadline > 0 {
+	} else if elem.Value.deadline > 0 {
 		b.startGCOnce()
-		if b.earliestExpireAt == 0 || elem.deadline < b.earliestExpireAt {
-			b.earliestExpireAt = elem.deadline
+		if b.earliestExpireAt == 0 || elem.Value.deadline < b.earliestExpireAt {
+			b.earliestExpireAt = elem.Value.deadline
 			b.timer.Reset(ttl)
 		}
 	}
 }
 
-func (b *Backend[K, V]) incAtomic(elem *Element[V]) {
+func (b *Backend[K, V]) hit(elem *ringlist.Element[Record[V]]) {
 	switch b.Policy {
+	case Default:
 	case LFU:
-		elem.epoch.Add(1)
+		b.list.MoveAfter(elem, elem.Next())
 	case LRU:
-		elem.epoch.Store(b.epoch.Add(1))
+		b.list.MoveAfter(elem, b.list.Back())
 	}
 }
 
 // Load an initialized element.
-func (b *Backend[K, V]) Load(key K) (value *Element[V], ok bool) {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
+func (b *Backend[K, V]) Load(key K) (value *ringlist.Element[Record[V]], ok bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
-	if elem, ok := b.xmap[key]; ok && elem.initialized {
-		b.incAtomic(elem)
+	if elem, ok := b.xmap[key]; ok && elem.Value.initialized {
+		b.hit(elem)
 		return elem, true
 	}
 
@@ -137,49 +134,42 @@ func (b *Backend[K, V]) Load(key K) (value *Element[V], ok bool) {
 }
 
 // LoadOrStore loads or stores an element.
-func (b *Backend[K, V]) LoadOrStore(key K, new *Element[V]) (old *Element[V], initialized, loaded bool) {
-	b.mu.RLock()
-	if elem, ok := b.xmap[key]; ok {
-		defer b.mu.RUnlock()
-		if elem.initialized {
-			b.incAtomic(elem)
-			return elem, true, true
-		}
-		return elem, false, true
-	}
-	b.mu.RUnlock()
-
+func (b *Backend[K, V]) LoadOrStore(key K, new *ringlist.Element[Record[V]]) (old *ringlist.Element[Record[V]], loaded bool) {
+tryLoadStore:
 	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	if elem, ok := b.xmap[key]; ok {
-		if elem.initialized {
-			b.incAtomic(elem)
-			return elem, true, true
+		if elem.Value.initialized {
+			b.hit(elem)
+			b.mu.Unlock()
+			return elem, true
 		}
-		return elem, false, true
+
+		b.mu.Unlock()
+		elem.Value.wg.Wait()
+		goto tryLoadStore
 	}
 
-	// New elements are at epoch 0.
 	b.xmap[key] = new
 
-	return new, false, false
+	b.mu.Unlock()
+
+	return new, false
 }
 
-// Range iterates over initialized cache elements in no particular order.
-func (b *Backend[K, V]) Range(f func(key K, r *Element[V]) bool) {
-	b.mu.RLock()
+// Range iterates over initialized cache elements in no particular order or consistency.
+func (b *Backend[K, V]) Range(f func(key K, r *ringlist.Element[Record[V]]) bool) {
+	b.mu.Lock()
 	keys := make([]K, 0, len(b.xmap))
-	for k := range b.xmap {
-		keys = append(keys, k)
+	for key := range b.xmap {
+		keys = append(keys, key)
 	}
-	b.mu.RUnlock()
+	b.mu.Unlock()
 
 	for _, key := range keys {
-		b.mu.RLock()
+		b.mu.Lock()
 		elem, ok := b.xmap[key]
-		initialized := ok && elem.initialized
-		b.mu.RUnlock()
+		initialized := ok && elem.Value.initialized
+		b.mu.Unlock()
 		if initialized && !f(key, elem) {
 			return
 		}
@@ -187,58 +177,40 @@ func (b *Backend[K, V]) Range(f func(key K, r *Element[V]) bool) {
 }
 
 // Evict an element.
-func (b *Backend[K, V]) Evict(key K) (*Element[V], bool) {
+func (b *Backend[K, V]) Evict(key K) (V, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if elem, ok := b.xmap[key]; ok && elem.initialized {
-		b.deleteLocked(key, elem)
-		return elem, true
+	var zero V
+
+	if elem, ok := b.xmap[key]; ok && elem.Value.initialized {
+		b.delete(key, elem)
+		return elem.Value.Value, true
 	}
 
-	return nil, false
-}
-
-// Delete an element from the backend map.
-// The element may be uninitialized.
-func (b *Backend[K, V]) Delete(key K) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	b.deleteLocked(key, nil)
+	return zero, false
 }
 
 // overflow returns the number of overflowed elements.
-// Note: b.list must not contain nil elements.
 func (b *Backend[K, V]) overflow() int {
-	if b.cap > 0 && b.len > b.cap {
-		return b.len - b.cap
+	if b.cap > 0 && b.list.Len() > b.cap {
+		return b.list.Len() - b.cap
 	}
 	return 0
 }
 
-func (b *Backend[K, V]) deleteLocked(key K, elem *Element[V]) {
-	if elem == nil {
-		elem = b.xmap[key]
-	}
-
-	if elem != nil {
-		delete(b.xmap, key)
-
-		if elem.initialized {
-			b.list[slices.Index(b.list, elem)] = nil
-			b.len--
-			b.numDeleted++
-		}
-	}
+func (b *Backend[K, V]) delete(key K, elem *ringlist.Element[Record[V]]) {
+	delete(b.xmap, key)
+	b.list.Remove(elem)
+	b.numDeleted++
 
 	if b.lastLen == 0 {
-		b.lastLen = b.len
+		b.lastLen = b.list.Len()
 	}
 
 	if b.numDeleted > uint64(b.lastLen)/2 {
 		b.numDeleted = 0
-		b.lastLen = b.len
+		b.lastLen = b.list.Len()
 		b.needRealloc = true
 		b.timer.Reset(0)
 	}
@@ -253,136 +225,63 @@ func (b *Backend[K, V]) startGCOnce() {
 					b.timer.Stop()
 					return
 				case now := <-b.timer.C:
-					b.runGC(now.UnixNano())
+					b.RunGC(now.UnixNano())
 				}
 			}
 		}()
 	})
 }
 
-func (b *Backend[K, V]) sort() {
-	largestEpoch := uint64(0)
-
-	slices.SortFunc(b.list, func(a, b *Element[V]) int {
-		// Leave nils at the beginning.
-		if a == nil && b != nil {
-			return -1
-		} else if a == nil && b == nil {
-			return 0
-		} else if a != nil && b == nil {
-			return 1
-		}
-
-		epochA := a.epoch.Load()
-		epochB := b.epoch.Load()
-		if epochA > largestEpoch {
-			largestEpoch = epochA
-		}
-		if epochB > largestEpoch {
-			largestEpoch = epochB
-		}
-
-		result := cmp.Compare(epochA, epochB)
-
-		// Leave newly added elements at the end.
-		if epochA == 0 || epochB == 0 {
-			return result * -1
-		}
-
-		return result
-	})
-
-	// Set largest epoch + 1 for new elements.
-	for i := len(b.list) - 1; i >= 0; i-- {
-		if b.list[i] == nil || !b.list[i].epoch.CompareAndSwap(0, largestEpoch+1) {
-			break
-		}
-	}
-}
-
-func (b *Backend[K, V]) collectOverflowed() map[*Element[V]]bool {
-	var overflowed map[*Element[V]]bool
-
-	if numOverflowed := b.overflow(); numOverflowed > 0 {
-		overflowed = make(map[*Element[V]]bool, numOverflowed)
-
-		for _, elem := range b.list {
-			if elem != nil {
-				overflowed[elem] = true
-				if len(overflowed) == numOverflowed {
-					break
-				}
-			}
-		}
-	}
-
-	return overflowed
-}
-
-func (b *Backend[K, V]) runGC(now int64) {
+func (b *Backend[K, V]) RunGC(now int64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	switch b.Policy {
-	case LFU, LRU:
-		b.sort()
-	}
-
-	overflowed := b.collectOverflowed()
-
 	var (
-		newMap  map[K]*Element[V]
-		newList []*Element[V]
+		overflowed    map[*ringlist.Element[Record[V]]]bool
+		numOverflowed = b.overflow()
 	)
 
-	if b.needRealloc {
-		b.needRealloc = false
-		newMap = make(map[K]*Element[V], len(b.xmap)-len(overflowed))
-		newList = make([]*Element[V], 0, len(b.xmap)-len(overflowed))
-		defer func() {
-			b.xmap = newMap
-			b.list = newList
-		}()
+	if numOverflowed > 0 {
+		overflowed = make(map[*ringlist.Element[Record[V]]]bool, numOverflowed)
+		b.list.Do(func(e *ringlist.Element[Record[V]]) bool {
+			if len(overflowed) == numOverflowed {
+				return false
+			}
+
+			overflowed[e] = true
+
+			return true
+		})
 	}
 
 	var earliest int64
-	defer func() {
-		b.earliestExpireAt = earliest
-		if earliest > 0 {
-			b.timer.Reset(time.Duration(earliest - now))
-		}
-	}()
 
 	for key, elem := range b.xmap {
-		if elem.initialized {
-			if len(overflowed) > 0 && overflowed[elem] {
-				delete(overflowed, elem)
-				b.deleteLocked(key, elem)
-				continue
-			}
-
-			deadline := elem.deadline
-
-			if deadline > 0 && deadline < now {
-				b.deleteLocked(key, elem)
-				continue
-			}
-
-			if deadline > 0 && (earliest == 0 || deadline < earliest) {
-				earliest = deadline
-			}
+		if len(overflowed) > 0 && overflowed[elem] {
+			delete(overflowed, elem)
+			b.delete(key, elem)
+			continue
 		}
 
-		if newMap != nil {
-			newMap[key] = elem
+		deadline := elem.Value.deadline
+
+		if deadline > 0 && deadline < now {
+			b.delete(key, elem)
+			continue
+		}
+
+		if deadline > 0 && (earliest == 0 || deadline < earliest) {
+			earliest = deadline
 		}
 	}
 
-	if newList != nil {
-		if first := slices.IndexFunc(b.list, func(e *Element[V]) bool {
-			return e != nil
-		}); first != -1 {
-			newList = append(newList, b.list[first:]...)
-		}
+	if b.needRealloc {
+		b.needRealloc = false
+		b.xmap = maps.Clone(b.xmap)
+	}
+
+	b.earliestExpireAt = earliest
+	if earliest > 0 {
+		b.timer.Reset(time.Duration(earliest - now))
 	}
 }

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -1,61 +1,344 @@
 package backend_test
 
 import (
+	"cmp"
+	"fmt"
+	"math/rand"
+	"runtime"
+	"slices"
+	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/mgnsk/evcache/v3/internal/backend"
 	. "github.com/mgnsk/evcache/v3/internal/testing"
 )
 
 func TestMapShrinkUninitializedRecords(t *testing.T) {
+	size := 1000
+
 	t.Run("realloc", func(t *testing.T) {
-		b := newBackend(size - 1)
-		AssertEqual(t, b.Len(), size-1)
-		AssertEqual(t, getInitializedMapLen(b), size-1)
+		b := backend.NewBackend[int, int](0)
 
-		// Store uninitialized record.
-		elem := b.Reserve()
-		b.LoadOrStore(size-1, elem)
-
-		AssertEqual(t, b.Len(), size-1)
-		AssertEqual(t, b.Len(), size-1)
-
-		// Evict half of records.
-		for i := 0; i < size/2; i++ {
-			b.Evict(i)
+		t.Log("filling the cache")
+		for i := 0; i < size; i++ {
+			elem, _, _ := b.LoadOrStore(i, b.Reserve())
+			b.Initialize(elem, i, 0)
 		}
 
-		b.RunGC(time.Now().UnixNano())
+		t.Log("asserting number of initialized elements is correct")
+		Equal(t, b.Len(), size)
+		Equal(t, getMapRangeCount(b), size)
 
-		// Initialize the record.
-		b.Initialize(size-1, 0, 0)
+		var elem *backend.Element[int]
 
-		AssertEqual(t, b.Len(), size/2)
-		AssertEqual(t, b.Len(), size/2)
+		t.Log("storing a new uninitialized element")
+		elem = b.Reserve()
+		_, initialized, loaded := b.LoadOrStore(size, elem)
+		Equal(t, initialized, false)
+		Equal(t, loaded, false)
+
+		t.Log("asserting number of initialized has not changed")
+		Equal(t, b.Len(), size)
+		Equal(t, getMapRangeCount(b), size)
+
+		t.Log("evicting half of records")
+		for i := 0; i < size/2; i++ {
+			_, ok := b.Evict(i)
+			Equal(t, ok, true)
+		}
+
+		t.Log("asserting number of initialized elements is correct")
+		Equal(t, b.Len(), size/2)
+		Equal(t, getMapRangeCount(b), size/2)
+
+		// Initialize the element.
+		b.Initialize(elem, 0, 0)
+
+		t.Log("asserting number of initialized elements has changed")
+		Equal(t, b.Len(), size/2+1)
+		Equal(t, getMapRangeCount(b), size/2+1)
 	})
 }
 
-// Note: backend constant.
-const size = 100000
-
-func newBackend(size int) *backend.Backend[int, int] {
+func TestDeleteUninitializedElement(t *testing.T) {
 	b := backend.NewBackend[int, int](0)
 
-	for i := 0; i < size; i++ {
-		b.LoadOrStore(i, b.Reserve())
-		b.Initialize(i, i, 0)
-	}
+	t.Log("storing a new uninitialized element")
+	elem := b.Reserve()
+	_, initialized, loaded := b.LoadOrStore(0, elem)
+	Equal(t, initialized, false)
+	Equal(t, loaded, false)
+	Equal(t, b.Len(), 0)
 
-	return b
+	_, evicted := b.Evict(0)
+	Equal(t, evicted, false)
+	Equal(t, b.Len(), 0)
+
+	b.Delete(0)
+	Equal(t, b.Len(), 0)
 }
 
-func getInitializedMapLen(b *backend.Backend[int, int]) int {
+func TestOverflowEvictionOrder(t *testing.T) {
+	const capacity = 10
+
+	t.Run("insert order", func(t *testing.T) {
+		t.Parallel()
+
+		b := backend.NewBackend[int, *string](capacity)
+
+		evictedKeys := fillCache(t, b, capacity)
+
+		// Overflow the cache and catch evicted keys.
+		keys := overflowAndCollectKeys(t, b, capacity, evictedKeys)
+
+		Equal(t, len(keys), capacity)
+		Equal(t, keys, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	})
+
+	t.Run("LFU order", func(t *testing.T) {
+		t.Parallel()
+
+		b := backend.NewBackend[int, *string](capacity)
+		b.Policy = backend.LFU
+
+		evictedKeys := fillCache(t, b, capacity)
+		_ = evictedKeys
+
+		t.Log("creating LFU test usage")
+		createLFUTestUsage(t, b, capacity)
+
+		// Overflow the cache and catch evicted keys.
+		keys := overflowAndCollectKeys(t, b, capacity, evictedKeys)
+
+		Equal(t, len(keys), capacity)
+		Equal(t, keys, []int{9, 8, 7, 6, 5, 4, 3, 2, 1, 0})
+	})
+
+	t.Run("LRU order", func(t *testing.T) {
+		t.Parallel()
+
+		b := backend.NewBackend[int, *string](capacity)
+		b.Policy = backend.LRU
+
+		evictedKeys := fillCache(t, b, capacity)
+		_ = evictedKeys
+
+		t.Log("creating LRU test usage")
+		createLRUTestUsage(t, b, capacity)
+
+		// Overflow the cache and catch evicted keys.
+		keys := overflowAndCollectKeys(t, b, capacity, evictedKeys)
+
+		Equal(t, len(keys), capacity)
+		Equal(t, keys, []int{9, 8, 7, 6, 5, 4, 3, 2, 1, 0})
+	})
+}
+
+func getMapRangeCount[K comparable, V any](b *backend.Backend[K, V]) int {
 	n := 0
-	b.Range(func(key int, elem backend.Element[int]) bool {
+
+	b.Range(func(K, *backend.Element[V]) bool {
 		n++
 		return true
 	})
 
 	return n
+}
+
+func fillCache(t *testing.T, b *backend.Backend[int, *string], capacity int) <-chan int {
+	evictedKeys := make(chan int, capacity)
+
+	for i := 0; i < capacity; i++ {
+		value := new(string)
+		i := i
+		runtime.SetFinalizer(value, func(any) {
+			t.Logf("sending evicted key %d", i)
+			evictedKeys <- i
+		})
+
+		elem := b.Reserve()
+
+		_, _, loaded := b.LoadOrStore(i, elem)
+		Equal(t, loaded, false)
+		b.Initialize(elem, value, 0)
+		Equal(t, b.Len(), i+1)
+	}
+
+	return evictedKeys
+}
+
+func createLFUTestUsage(t *testing.T, b *backend.Backend[int, *string], capacity int) {
+	for i := 0; i < capacity; i++ {
+		// Increase hit counts in list reverse order.
+		hits := capacity * (capacity - i)
+		t.Logf("LFU test usage: key=%d, hits=%d\n", i, hits)
+
+		for n := 0; n < hits; n++ {
+			_, loaded := b.Load(i)
+			Equal(t, loaded, true)
+		}
+	}
+}
+
+func createLRUTestUsage(t *testing.T, b *backend.Backend[int, *string], capacity int) {
+	// Hit the cache in reverse order.
+	for i := capacity - 1; i >= 0; i-- {
+		_, loaded := b.Load(i)
+		Equal(t, loaded, true)
+	}
+}
+
+func overflowAndCollectKeys(t *testing.T, b *backend.Backend[int, *string], capacity int, evictedKeys <-chan int) (keys []int) {
+	t.Helper()
+
+	for i := 0; i < capacity; i++ {
+		i := i + capacity
+
+		elem := b.Reserve()
+		_, _, loaded := b.LoadOrStore(i, elem)
+		Equal(t, loaded, false)
+		b.Initialize(elem, nil, 0)
+
+		EventuallyTrue(t, func() bool {
+			runtime.GC()
+			select {
+			case key := <-evictedKeys:
+				t.Logf("received evicted key %d", key)
+				keys = append(keys, key)
+				return true
+			default:
+				return false
+			}
+		})
+	}
+
+	return keys
+}
+
+func BenchmarkSliceLoop(b *testing.B) {
+	b.Run("value elements", func(b *testing.B) {
+		for _, n := range []int{
+			1e3,
+			1e4,
+			1e5,
+			1e6,
+		} {
+			runtime.GC()
+
+			items := createSlice[int](n, nil)
+
+			b.Run(fmt.Sprint(n), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					for _, elem := range items {
+						if elem.Value > 0 {
+							panic("expected zero")
+						}
+					}
+				}
+
+				b.StopTimer()
+
+				nsPerElement := float64(b.Elapsed().Nanoseconds()) / float64(b.N) / float64(len(items))
+				b.ReportMetric(nsPerElement, "ns/element")
+			})
+		}
+	})
+
+	b.Run("atomic elements", func(b *testing.B) {
+		for _, n := range []int{
+			1e3,
+			1e4,
+			1e5,
+			1e6,
+		} {
+			runtime.GC()
+
+			items := createSlice[atomic.Uint64](n, nil)
+
+			b.Run(fmt.Sprint(n), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					for _, elem := range items {
+						if elem.Value.Load() > 0 {
+							panic("expected zero")
+						}
+					}
+				}
+
+				b.StopTimer()
+
+				nsPerElement := float64(b.Elapsed().Nanoseconds()) / float64(b.N) / float64(len(items))
+				b.ReportMetric(nsPerElement, "ns/element")
+			})
+		}
+	})
+}
+
+func BenchmarkSliceSort(b *testing.B) {
+	b.Run("value elements", func(b *testing.B) {
+		for _, n := range []int{
+			1e3,
+			1e4,
+			1e5,
+			1e6,
+		} {
+			runtime.GC()
+
+			items := createSlice(n, func(v *int) {
+				*v = rand.Int()
+			})
+
+			b.Run(fmt.Sprint(n), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					slices.SortFunc(items, func(a, b *backend.Element[int]) int {
+						return cmp.Compare(a.Value, b.Value)
+					})
+				}
+
+				b.StopTimer()
+
+				nsPerElement := float64(b.Elapsed().Nanoseconds()) / float64(b.N) / float64(len(items))
+				b.ReportMetric(nsPerElement, "ns/element")
+			})
+		}
+	})
+
+	b.Run("atomic elements", func(b *testing.B) {
+		for _, n := range []int{
+			1e3,
+			1e4,
+			1e5,
+			1e6,
+		} {
+			runtime.GC()
+
+			items := createSlice(n, func(u *atomic.Uint64) {
+				u.Store(rand.Uint64())
+			})
+
+			b.Run(fmt.Sprint(n), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					slices.SortFunc(items, func(a, b *backend.Element[atomic.Uint64]) int {
+						return cmp.Compare(a.Value.Load(), b.Value.Load())
+					})
+				}
+
+				b.StopTimer()
+
+				nsPerElement := float64(b.Elapsed().Nanoseconds()) / float64(b.N) / float64(len(items))
+				b.ReportMetric(nsPerElement, "ns/element")
+			})
+		}
+	})
+}
+
+func createSlice[V any](n int, valueFn func(*V)) []*backend.Element[V] {
+	items := make([]*backend.Element[V], n)
+	for i := 0; i < len(items); i++ {
+		items[i] = &backend.Element[V]{}
+		if valueFn != nil {
+			valueFn(&items[i].Value)
+		}
+	}
+
+	return items
 }

--- a/internal/backend/benchmark_test.go
+++ b/internal/backend/benchmark_test.go
@@ -1,0 +1,262 @@
+package backend_test
+
+import (
+	"cmp"
+	"fmt"
+	"math/rand"
+	"runtime"
+	"slices"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mgnsk/evcache/v3/internal/backend"
+	. "github.com/mgnsk/evcache/v3/internal/testing"
+)
+
+func BenchmarkSliceLoop(b *testing.B) {
+	b.Run("value elements", func(b *testing.B) {
+		for _, n := range []int{
+			1e3,
+			1e4,
+			1e5,
+			1e6,
+		} {
+			b.Run(fmt.Sprint(n), newTimePerElementBench(
+				func() ([]*backend.Record[int], int) {
+					items := createSlice[int](n, nil)
+					return items, len(items)
+				},
+				func(items []*backend.Record[int]) {
+					for _, elem := range items {
+						if elem.Value > 0 {
+							panic("expected zero")
+						}
+					}
+				},
+			))
+		}
+	})
+
+	b.Run("atomic elements", func(b *testing.B) {
+		for _, n := range []int{
+			1e3,
+			1e4,
+			1e5,
+			1e6,
+		} {
+			b.Run(fmt.Sprint(n), newTimePerElementBench(
+				func() ([]*backend.Record[atomic.Uint64], int) {
+					items := createSlice[atomic.Uint64](n, nil)
+					return items, len(items)
+				},
+				func(items []*backend.Record[atomic.Uint64]) {
+					for _, elem := range items {
+						if elem.Value.Load() > 0 {
+							panic("expected zero")
+						}
+					}
+				},
+			))
+		}
+	})
+}
+
+func BenchmarkMapIter(b *testing.B) {
+	for _, n := range []int{
+		1e3,
+		1e4,
+		1e5,
+		1e6,
+	} {
+		b.Run(fmt.Sprint(n), newTimePerElementBench(
+			func() (map[int]*backend.Record[int], int) {
+				m := createMap[int, int](n, nil)
+				return m, n
+			},
+			func(m map[int]*backend.Record[int]) {
+				for _, elem := range m {
+					if elem.Value > 0 {
+						panic("expected zero")
+					}
+				}
+			},
+		))
+	}
+}
+
+func BenchmarkSliceSort(b *testing.B) {
+	b.Run("value elements", func(b *testing.B) {
+		for _, n := range []int{
+			1e3,
+			1e4,
+			1e5,
+			1e6,
+		} {
+			b.Run(fmt.Sprint(n), newTimePerElementBench(
+				func() ([]*backend.Record[int], int) {
+					items := createSlice(n, func(v *int) {
+						*v = rand.Int()
+					})
+					return items, len(items)
+				},
+				func(items []*backend.Record[int]) {
+					slices.SortFunc(items, func(a, b *backend.Record[int]) int {
+						return cmp.Compare(a.Value, b.Value)
+					})
+				},
+			))
+		}
+	})
+
+	b.Run("atomic elements", func(b *testing.B) {
+		for _, n := range []int{
+			1e3,
+			1e4,
+			1e5,
+			1e6,
+		} {
+			b.Run(fmt.Sprint(n), newTimePerElementBench(
+				func() ([]*backend.Record[atomic.Uint64], int) {
+					items := createSlice(n, func(u *atomic.Uint64) {
+						u.Store(rand.Uint64())
+					})
+					return items, len(items)
+				},
+				func(items []*backend.Record[atomic.Uint64]) {
+					slices.SortFunc(items, func(a, b *backend.Record[atomic.Uint64]) int {
+						return cmp.Compare(a.Value.Load(), b.Value.Load())
+					})
+				},
+			))
+		}
+	})
+}
+
+func BenchmarkBackendGC(b *testing.B) {
+	for _, n := range []int{
+		1e3,
+		1e4,
+		1e5,
+		1e6,
+	} {
+		b.Run(fmt.Sprint(n), newTimePerElementBench(
+			func() (*backend.Backend[int, int], int) {
+				be := backend.NewBackend[int, int](n)
+				for i := 0; i < n; i++ {
+					elem := be.Reserve()
+					_, loaded := be.LoadOrStore(i, elem)
+					Equal(b, loaded, false)
+					be.Initialize(elem, 0, 0)
+				}
+
+				return be, be.Len()
+			},
+			func(be *backend.Backend[int, int]) {
+				be.RunGC(0)
+			},
+		))
+	}
+}
+
+func BenchmarkBackendGCLFU(b *testing.B) {
+	for _, n := range []int{
+		1e3,
+		1e4,
+		1e5,
+		1e6,
+	} {
+		b.Run(fmt.Sprint(n), newTimePerElementBench(
+			func() (*backend.Backend[int, int], int) {
+				be := backend.NewBackend[int, int](n)
+				be.Policy = backend.LFU
+
+				for i := 0; i < n; i++ {
+					elem := be.Reserve()
+					_, loaded := be.LoadOrStore(i, elem)
+					Equal(b, loaded, false)
+					be.Initialize(elem, 0, 0)
+				}
+
+				return be, be.Len()
+			},
+			func(be *backend.Backend[int, int]) {
+				be.RunGC(0)
+			},
+		))
+	}
+}
+
+func BenchmarkBackendGCLRU(b *testing.B) {
+	for _, n := range []int{
+		1e3,
+		1e4,
+		1e5,
+		1e6,
+	} {
+		b.Run(fmt.Sprint(n), newTimePerElementBench(
+			func() (*backend.Backend[int, int], int) {
+				be := backend.NewBackend[int, int](n)
+				be.Policy = backend.LRU
+
+				for i := 0; i < n; i++ {
+					elem := be.Reserve()
+					_, loaded := be.LoadOrStore(i, elem)
+					Equal(b, loaded, false)
+					be.Initialize(elem, 0, 0)
+				}
+
+				return be, be.Len()
+			},
+			func(be *backend.Backend[int, int]) {
+				be.RunGC(0)
+			},
+		))
+	}
+}
+
+func createSlice[V any](n int, valueFn func(*V)) []*backend.Record[V] {
+	items := make([]*backend.Record[V], n)
+	for i := 0; i < len(items); i++ {
+		items[i] = &backend.Record[V]{}
+		if valueFn != nil {
+			valueFn(&items[i].Value)
+		}
+	}
+
+	return items
+}
+
+func createMap[K comparable, V any](n int, valueFn func(*K, *V)) map[K]*backend.Record[V] {
+	m := make(map[K]*backend.Record[V], n)
+	for i := 0; i < n; i++ {
+		key := *new(K)
+		value := *new(V)
+
+		if valueFn != nil {
+			valueFn(&key, &value)
+		}
+
+		m[key] = &backend.Record[V]{Value: value}
+	}
+
+	return m
+}
+
+func newTimePerElementBench[S any](createSubject func() (S, int), iterate func(S)) func(b *testing.B) {
+	runtime.GC()
+
+	subject, n := createSubject()
+
+	return func(b *testing.B) {
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			iterate(subject)
+		}
+
+		b.StopTimer()
+
+		nsPerElement := float64(b.Elapsed().Nanoseconds()) / float64(b.N) / float64(n)
+		b.ReportMetric(nsPerElement, "ns/element")
+	}
+}

--- a/internal/backend/element.go
+++ b/internal/backend/element.go
@@ -1,0 +1,20 @@
+package backend
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Element is a cache element.
+type Element[V any] struct {
+	Value       V
+	deadline    int64
+	epoch       atomic.Uint64
+	wg          sync.WaitGroup
+	initialized bool
+}
+
+// Wait for the record to be initialized or discarded.
+func (e *Element[V]) Wait() {
+	e.wg.Wait()
+}

--- a/internal/backend/element.go
+++ b/internal/backend/element.go
@@ -2,19 +2,12 @@ package backend
 
 import (
 	"sync"
-	"sync/atomic"
 )
 
-// Element is a cache element.
-type Element[V any] struct {
+// Record is a cache record.
+type Record[V any] struct {
 	Value       V
 	deadline    int64
-	epoch       atomic.Uint64
-	wg          sync.WaitGroup
 	initialized bool
-}
-
-// Wait for the record to be initialized or discarded.
-func (e *Element[V]) Wait() {
-	e.wg.Wait()
+	wg          sync.WaitGroup
 }

--- a/internal/backend/policy.go
+++ b/internal/backend/policy.go
@@ -1,0 +1,11 @@
+package backend
+
+// Policy is a cache eviction policy.
+type Policy int
+
+// Available cache eviction policies.
+const (
+	Default Policy = iota
+	LFU
+	LRU
+)

--- a/internal/testing/assert.go
+++ b/internal/testing/assert.go
@@ -6,24 +6,30 @@ import (
 	"time"
 )
 
-// AssertSuccess that error did not occur.
-func AssertSuccess(t testing.TB, err error) {
-	if err != nil || !isNil(err) {
+// Must that error did not occur.
+func Must(t testing.TB, err error) {
+	t.Helper()
+
+	if err != nil {
 		t.Fatalf("expected success")
 	}
 }
 
-// AssertEqual asserts that values are deeply equal.
-func AssertEqual[T any](t testing.TB, a, b T) {
+// Equal asserts that values are deeply equal.
+func Equal[T any](t testing.TB, a, b T) {
+	t.Helper()
+
 	if !reflect.DeepEqual(a, b) {
 		t.Fatalf("expected '%v' to be equal to '%v'", a, b)
 	}
 }
 
-// AssertEventuallyTrue asserts that f eventually returns true.
-func AssertEventuallyTrue(t testing.TB, f func() bool, timeout ...time.Duration) {
+// EventuallyTrue asserts that f eventually returns true.
+func EventuallyTrue(t testing.TB, f func() bool, timeout ...time.Duration) {
+	t.Helper()
+
 	limit := time.Second
-	if timeout != nil {
+	if len(timeout) > 0 {
 		limit = timeout[0]
 	}
 
@@ -44,17 +50,4 @@ func AssertEventuallyTrue(t testing.TB, f func() bool, timeout ...time.Duration)
 			}
 		}
 	}
-}
-
-func isNil(a interface{}) bool {
-	if a == nil {
-		return true
-	}
-
-	switch reflect.TypeOf(a).Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
-		return reflect.ValueOf(a).IsNil()
-	}
-
-	return false
 }


### PR DESCRIPTION
Implements ringlist based cache backend with mutex so that cache hits can be stored immediately when element is loaded.